### PR TITLE
Add compliance reminder tracking and dashboard task counts

### DIFF
--- a/Models/SystemEntity.cs
+++ b/Models/SystemEntity.cs
@@ -8,22 +8,59 @@ public class SystemEntity
     public int SystemId { get; set; }
 
     public string SystemCode { get; set; } = string.Empty;
-
     public string SystemName { get; set; } = string.Empty;
-
     public int DepartmentId { get; set; }
-
     public string Owner { get; set; } = string.Empty;
-
     public string Vendor { get; set; } = string.Empty;
-
     public string SoftwareVersion { get; set; } = string.Empty;
-
     public string GampCategory { get; set; } = string.Empty;
-
     public string IsGxpRelevant { get; set; } = string.Empty;
-
     public string ValidationStatus { get; set; } = string.Empty;
-
     public bool IsObsolete { get; set; } = false;
+
+    public DateTime? LastReviewDate { get; set; }
+    public int ReviewFrequencyMonths { get; set; } = 12;
+
+    public DateTime? LastBackupDate { get; set; }
+    public int BackupFrequencyMonths { get; set; } = 3;
+
+    public DateTime? LastAuditTrailReviewDate { get; set; }
+    public int AuditTrailFrequencyMonths { get; set; } = 3;
+
+    [Ignore]
+    public DateTime? NextReviewDueDate => LastReviewDate?.Date.AddMonths(ReviewFrequencyMonths);
+
+    [Ignore]
+    public DateTime? NextBackupDueDate => LastBackupDate?.Date.AddMonths(BackupFrequencyMonths);
+
+    [Ignore]
+    public DateTime? NextAuditTrailDueDate => LastAuditTrailReviewDate?.Date.AddMonths(AuditTrailFrequencyMonths);
+
+    [Ignore]
+    public string ReviewStatusMessage => GetStatusMessage(NextReviewDueDate);
+
+    [Ignore]
+    public string BackupStatusMessage => GetStatusMessage(NextBackupDueDate);
+
+    [Ignore]
+    public string AuditTrailStatusMessage => GetStatusMessage(NextAuditTrailDueDate);
+
+    private string GetStatusMessage(DateTime? dueDate)
+    {
+        if (dueDate == null)
+            return "No schedule set";
+
+        int days = (dueDate.Value.Date - DateTime.Today).Days;
+
+        if (days < 0)
+            return $"Overdue by {Math.Abs(days)} day(s)";
+
+        if (days == 0)
+            return "Due today";
+
+        if (days <= 30)
+            return $"Due in {days} day(s)";
+
+        return $"Due in {days} day(s)";
+    }
 }

--- a/Services/DatabaseService.cs
+++ b/Services/DatabaseService.cs
@@ -12,7 +12,7 @@ public class DatabaseService
         if (_database != null)
             return;
 
-        var databasePath = Path.Combine(FileSystem.AppDataDirectory, "gxp_inventory.db");
+        var databasePath = Path.Combine(FileSystem.AppDataDirectory, "gxp_inventory_v3.db");
 
         _database = new SQLiteAsyncConnection(databasePath);
 

--- a/ViewModels/SystemViewModel.cs
+++ b/ViewModels/SystemViewModel.cs
@@ -43,6 +43,14 @@ public class SystemViewModel : INotifyPropertyChanged
         "Not Validated"
     };
 
+    public ObservableCollection<int> FrequencyOptions { get; set; } = new()
+    {
+        1,
+        3,
+        6,
+        12
+    };
+
     public SystemEntity? SelectedSystem { get; set; }
 
     public int TotalSystems => Systems.Count;
@@ -51,6 +59,12 @@ public class SystemViewModel : INotifyPropertyChanged
     public int InProgressSystems => Systems.Count(s => s.ValidationStatus.Equals("In Progress", StringComparison.OrdinalIgnoreCase));
     public int NotValidatedSystems => Systems.Count(s => s.ValidationStatus.Equals("Not Validated", StringComparison.OrdinalIgnoreCase));
     public int ObsoleteSystemsCount => ObsoleteSystems.Count;
+
+    public int UpcomingComplianceTasks => Systems.Sum(s =>
+        CountUpcomingTasks(s));
+
+    public int OverdueComplianceTasks => Systems.Sum(s =>
+        CountOverdueTasks(s));
 
     private string _systemCode = string.Empty;
     public string SystemCode
@@ -115,6 +129,48 @@ public class SystemViewModel : INotifyPropertyChanged
         set { _validationStatus = value; OnPropertyChanged(); }
     }
 
+    private DateTime _lastReviewDate = DateTime.Today;
+    public DateTime LastReviewDate
+    {
+        get => _lastReviewDate;
+        set { _lastReviewDate = value; OnPropertyChanged(); }
+    }
+
+    private int _reviewFrequencyMonths = 12;
+    public int ReviewFrequencyMonths
+    {
+        get => _reviewFrequencyMonths;
+        set { _reviewFrequencyMonths = value; OnPropertyChanged(); }
+    }
+
+    private DateTime _lastBackupDate = DateTime.Today;
+    public DateTime LastBackupDate
+    {
+        get => _lastBackupDate;
+        set { _lastBackupDate = value; OnPropertyChanged(); }
+    }
+
+    private int _backupFrequencyMonths = 3;
+    public int BackupFrequencyMonths
+    {
+        get => _backupFrequencyMonths;
+        set { _backupFrequencyMonths = value; OnPropertyChanged(); }
+    }
+
+    private DateTime _lastAuditTrailReviewDate = DateTime.Today;
+    public DateTime LastAuditTrailReviewDate
+    {
+        get => _lastAuditTrailReviewDate;
+        set { _lastAuditTrailReviewDate = value; OnPropertyChanged(); }
+    }
+
+    private int _auditTrailFrequencyMonths = 3;
+    public int AuditTrailFrequencyMonths
+    {
+        get => _auditTrailFrequencyMonths;
+        set { _auditTrailFrequencyMonths = value; OnPropertyChanged(); }
+    }
+
     public SystemViewModel(SystemRepository systemRepository)
     {
         _systemRepository = systemRepository;
@@ -153,7 +209,13 @@ public class SystemViewModel : INotifyPropertyChanged
             GampCategory = SelectedGampCategory,
             IsGxpRelevant = SelectedGxpOption,
             ValidationStatus = ValidationStatus,
-            IsObsolete = false
+            IsObsolete = false,
+            LastReviewDate = LastReviewDate,
+            ReviewFrequencyMonths = ReviewFrequencyMonths,
+            LastBackupDate = LastBackupDate,
+            BackupFrequencyMonths = BackupFrequencyMonths,
+            LastAuditTrailReviewDate = LastAuditTrailReviewDate,
+            AuditTrailFrequencyMonths = AuditTrailFrequencyMonths
         };
 
         await _systemRepository.AddSystemAsync(newSystem);
@@ -183,6 +245,63 @@ public class SystemViewModel : INotifyPropertyChanged
         await LoadSystemsAsync();
     }
 
+    private DateTime? GetNextDueDate(DateTime? lastCompletedDate, int frequencyMonths)
+    {
+        if (lastCompletedDate == null || frequencyMonths <= 0)
+            return null;
+
+        return lastCompletedDate.Value.Date.AddMonths(frequencyMonths);
+    }
+
+    private int CountUpcomingTasks(SystemEntity system)
+    {
+        int count = 0;
+
+        if (IsUpcoming(GetNextDueDate(system.LastReviewDate, system.ReviewFrequencyMonths)))
+            count++;
+
+        if (IsUpcoming(GetNextDueDate(system.LastBackupDate, system.BackupFrequencyMonths)))
+            count++;
+
+        if (IsUpcoming(GetNextDueDate(system.LastAuditTrailReviewDate, system.AuditTrailFrequencyMonths)))
+            count++;
+
+        return count;
+    }
+
+    private int CountOverdueTasks(SystemEntity system)
+    {
+        int count = 0;
+
+        if (IsOverdue(GetNextDueDate(system.LastReviewDate, system.ReviewFrequencyMonths)))
+            count++;
+
+        if (IsOverdue(GetNextDueDate(system.LastBackupDate, system.BackupFrequencyMonths)))
+            count++;
+
+        if (IsOverdue(GetNextDueDate(system.LastAuditTrailReviewDate, system.AuditTrailFrequencyMonths)))
+            count++;
+
+        return count;
+    }
+
+    private bool IsUpcoming(DateTime? nextDueDate)
+    {
+        if (nextDueDate == null)
+            return false;
+
+        return nextDueDate.Value.Date >= DateTime.Today &&
+               nextDueDate.Value.Date <= DateTime.Today.AddDays(60);
+    }
+
+    private bool IsOverdue(DateTime? nextDueDate)
+    {
+        if (nextDueDate == null)
+            return false;
+
+        return nextDueDate.Value.Date < DateTime.Today;
+    }
+
     private int GetDepartmentId(string departmentName)
     {
         return departmentName switch
@@ -207,6 +326,15 @@ public class SystemViewModel : INotifyPropertyChanged
         SelectedGampCategory = string.Empty;
         SelectedGxpOption = string.Empty;
         ValidationStatus = string.Empty;
+
+        LastReviewDate = DateTime.Today;
+        ReviewFrequencyMonths = 12;
+
+        LastBackupDate = DateTime.Today;
+        BackupFrequencyMonths = 3;
+
+        LastAuditTrailReviewDate = DateTime.Today;
+        AuditTrailFrequencyMonths = 3;
     }
 
     private void RefreshDashboardCounts()
@@ -217,6 +345,8 @@ public class SystemViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InProgressSystems));
         OnPropertyChanged(nameof(NotValidatedSystems));
         OnPropertyChanged(nameof(ObsoleteSystemsCount));
+        OnPropertyChanged(nameof(UpcomingComplianceTasks));
+        OnPropertyChanged(nameof(OverdueComplianceTasks));
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Views/AddSystemPage.xaml
+++ b/Views/AddSystemPage.xaml
@@ -14,7 +14,7 @@
                    HorizontalOptions="Center"
                    TextColor="#1E293B" />
 
-            <Label Text="Enter the computerised system details below."
+            <Label Text="Enter the computerised system details and compliance schedule."
                    FontSize="14"
                    TextColor="#64748B"
                    HorizontalTextAlignment="Center" />
@@ -22,51 +22,105 @@
             <Border StrokeThickness="1"
                     Stroke="#D8DEE9"
                     BackgroundColor="#FFFFFF"
-                    StrokeShape="RoundRectangle 16"
+                    StrokeShape="RoundRectangle 18"
                     Padding="18"
                     Margin="0,10,0,0">
 
-                <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="18">
 
-                    <Label Text="System ID" FontAttributes="Bold" TextColor="#334155" />
-                    <Entry Text="{Binding SystemCode}"
-                           Placeholder="e.g. LAB-UV-001" />
+                    <Border StrokeThickness="0"
+                            BackgroundColor="#F8FAFC"
+                            Padding="16"
+                            StrokeShape="RoundRectangle 16">
 
-                    <Label Text="System Name" FontAttributes="Bold" TextColor="#334155" />
-                    <Entry Text="{Binding SystemName}"
-                           Placeholder="e.g. Empower, Polarimeter, LabSolutions" />
+                        <VerticalStackLayout Spacing="14">
 
-                    <Label Text="Department" FontAttributes="Bold" TextColor="#334155" />
-                    <Picker Title="Select department"
-                            ItemsSource="{Binding Departments}"
-                            SelectedItem="{Binding SelectedDepartment}" />
+                            <Label Text="System Details"
+                                   FontSize="18"
+                                   FontAttributes="Bold"
+                                   TextColor="#1E293B" />
 
-                    <Label Text="System Owner" FontAttributes="Bold" TextColor="#334155" />
-                    <Entry Text="{Binding Owner}"
-                           Placeholder="e.g. QC Manager" />
+                            <Label Text="System ID" FontAttributes="Bold" TextColor="#334155" />
+                            <Entry Text="{Binding SystemCode}"
+                                   Placeholder="e.g. LAB-UV-001" />
 
-                    <Label Text="Vendor" FontAttributes="Bold" TextColor="#334155" />
-                    <Entry Text="{Binding Vendor}"
-                           Placeholder="e.g. Waters, Hanleys, Shimadzu" />
+                            <Label Text="System Name" FontAttributes="Bold" TextColor="#334155" />
+                            <Entry Text="{Binding SystemName}"
+                                   Placeholder="e.g. Empower, Polarimeter, LabSolutions" />
 
-                    <Label Text="Software Version" FontAttributes="Bold" TextColor="#334155" />
-                    <Entry Text="{Binding SoftwareVersion}"
-                           Placeholder="e.g. v1.0, LabSolutions 6.111" />
+                            <Label Text="Department" FontAttributes="Bold" TextColor="#334155" />
+                            <Picker Title="Select department"
+                                    ItemsSource="{Binding Departments}"
+                                    SelectedItem="{Binding SelectedDepartment}" />
 
-                    <Label Text="GAMP 5 Category" FontAttributes="Bold" TextColor="#334155" />
-                    <Picker Title="Select GAMP 5 category"
-                            ItemsSource="{Binding GampCategories}"
-                            SelectedItem="{Binding SelectedGampCategory}" />
+                            <Label Text="System Owner" FontAttributes="Bold" TextColor="#334155" />
+                            <Entry Text="{Binding Owner}"
+                                   Placeholder="e.g. QC Manager" />
 
-                    <Label Text="GxP Relevant?" FontAttributes="Bold" TextColor="#334155" />
-                    <Picker Title="Select Yes or No"
-                            ItemsSource="{Binding GxpOptions}"
-                            SelectedItem="{Binding SelectedGxpOption}" />
+                            <Label Text="Vendor" FontAttributes="Bold" TextColor="#334155" />
+                            <Entry Text="{Binding Vendor}"
+                                   Placeholder="e.g. Waters, Hanleys, Shimadzu" />
 
-                    <Label Text="Validation Status" FontAttributes="Bold" TextColor="#334155" />
-                    <Picker Title="Select validation status"
-                            ItemsSource="{Binding ValidationStatuses}"
-                            SelectedItem="{Binding ValidationStatus}" />
+                            <Label Text="Software Version" FontAttributes="Bold" TextColor="#334155" />
+                            <Entry Text="{Binding SoftwareVersion}"
+                                   Placeholder="e.g. v1.0, LabSolutions 6.111" />
+
+                            <Label Text="GAMP 5 Category" FontAttributes="Bold" TextColor="#334155" />
+                            <Picker Title="Select GAMP 5 category"
+                                    ItemsSource="{Binding GampCategories}"
+                                    SelectedItem="{Binding SelectedGampCategory}" />
+
+                            <Label Text="GxP Relevant?" FontAttributes="Bold" TextColor="#334155" />
+                            <Picker Title="Select Yes or No"
+                                    ItemsSource="{Binding GxpOptions}"
+                                    SelectedItem="{Binding SelectedGxpOption}" />
+
+                            <Label Text="Validation Status" FontAttributes="Bold" TextColor="#334155" />
+                            <Picker Title="Select validation status"
+                                    ItemsSource="{Binding ValidationStatuses}"
+                                    SelectedItem="{Binding ValidationStatus}" />
+
+                        </VerticalStackLayout>
+                    </Border>
+
+                    <Border StrokeThickness="0"
+                            BackgroundColor="#EEF2FF"
+                            Padding="16"
+                            StrokeShape="RoundRectangle 16">
+
+                        <VerticalStackLayout Spacing="14">
+
+                            <Label Text="Compliance Schedule"
+                                   FontSize="18"
+                                   FontAttributes="Bold"
+                                   TextColor="#3730A3" />
+
+                            <Label Text="Last Periodic Review Date" FontAttributes="Bold" TextColor="#334155" />
+                            <DatePicker Date="{Binding LastReviewDate}" />
+
+                            <Label Text="Periodic Review Frequency (months)" FontAttributes="Bold" TextColor="#334155" />
+                            <Picker Title="Select frequency"
+                                    ItemsSource="{Binding FrequencyOptions}"
+                                    SelectedItem="{Binding ReviewFrequencyMonths}" />
+
+                            <Label Text="Last Backup Verification Date" FontAttributes="Bold" TextColor="#334155" />
+                            <DatePicker Date="{Binding LastBackupDate}" />
+
+                            <Label Text="Backup Verification Frequency (months)" FontAttributes="Bold" TextColor="#334155" />
+                            <Picker Title="Select frequency"
+                                    ItemsSource="{Binding FrequencyOptions}"
+                                    SelectedItem="{Binding BackupFrequencyMonths}" />
+
+                            <Label Text="Last Audit Trail Review Date" FontAttributes="Bold" TextColor="#334155" />
+                            <DatePicker Date="{Binding LastAuditTrailReviewDate}" />
+
+                            <Label Text="Audit Trail Review Frequency (months)" FontAttributes="Bold" TextColor="#334155" />
+                            <Picker Title="Select frequency"
+                                    ItemsSource="{Binding FrequencyOptions}"
+                                    SelectedItem="{Binding AuditTrailFrequencyMonths}" />
+
+                        </VerticalStackLayout>
+                    </Border>
 
                     <Button Text="Save System"
                             FontAttributes="Bold"

--- a/Views/EditSystemPage.xaml
+++ b/Views/EditSystemPage.xaml
@@ -14,34 +14,95 @@
                    HorizontalOptions="Center"
                    TextColor="#1E293B" />
 
+            <Label Text="Update system details and compliance schedule."
+                   FontSize="14"
+                   TextColor="#64748B"
+                   HorizontalTextAlignment="Center" />
+
             <Border StrokeThickness="1"
                     Stroke="#D8DEE9"
                     BackgroundColor="#FFFFFF"
-                    StrokeShape="RoundRectangle 16"
+                    StrokeShape="RoundRectangle 18"
                     Padding="18">
 
-                <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="18">
 
-                    <Label Text="System Name" FontAttributes="Bold"/>
-                    <Entry Text="{Binding SelectedSystem.SystemName}" />
+                    <Border StrokeThickness="0"
+                            BackgroundColor="#F8FAFC"
+                            Padding="16"
+                            StrokeShape="RoundRectangle 16">
 
-                    <Label Text="Owner" FontAttributes="Bold"/>
-                    <Entry Text="{Binding SelectedSystem.Owner}" />
+                        <VerticalStackLayout Spacing="14">
 
-                    <Label Text="Vendor" FontAttributes="Bold"/>
-                    <Entry Text="{Binding SelectedSystem.Vendor}" />
+                            <Label Text="System Details"
+                                   FontSize="18"
+                                   FontAttributes="Bold"
+                                   TextColor="#1E293B" />
 
-                    <Label Text="Software Version" FontAttributes="Bold"/>
-                    <Entry Text="{Binding SelectedSystem.SoftwareVersion}" />
+                            <Label Text="System Name" FontAttributes="Bold" TextColor="#334155"/>
+                            <Entry Text="{Binding SelectedSystem.SystemName}" />
 
-                    <Label Text="Validation Status" FontAttributes="Bold"/>
-                    <Picker ItemsSource="{Binding ValidationStatuses}"
-                            SelectedItem="{Binding SelectedSystem.ValidationStatus}" />
+                            <Label Text="Owner" FontAttributes="Bold" TextColor="#334155"/>
+                            <Entry Text="{Binding SelectedSystem.Owner}" />
+
+                            <Label Text="Vendor" FontAttributes="Bold" TextColor="#334155"/>
+                            <Entry Text="{Binding SelectedSystem.Vendor}" />
+
+                            <Label Text="Software Version" FontAttributes="Bold" TextColor="#334155"/>
+                            <Entry Text="{Binding SelectedSystem.SoftwareVersion}" />
+
+                            <Label Text="Validation Status" FontAttributes="Bold" TextColor="#334155"/>
+                            <Picker ItemsSource="{Binding ValidationStatuses}"
+                                    SelectedItem="{Binding SelectedSystem.ValidationStatus}" />
+
+                        </VerticalStackLayout>
+                    </Border>
+
+                    <Border StrokeThickness="0"
+                            BackgroundColor="#EEF2FF"
+                            Padding="16"
+                            StrokeShape="RoundRectangle 16">
+
+                        <VerticalStackLayout Spacing="14">
+
+                            <Label Text="Compliance Schedule"
+                                   FontSize="18"
+                                   FontAttributes="Bold"
+                                   TextColor="#3730A3" />
+
+                            <Label Text="Last Periodic Review Date" FontAttributes="Bold" TextColor="#334155"/>
+                            <DatePicker Date="{Binding SelectedSystem.LastReviewDate}" />
+
+                            <Label Text="Periodic Review Frequency (months)" FontAttributes="Bold" TextColor="#334155"/>
+                            <Picker Title="Select frequency"
+                                    ItemsSource="{Binding FrequencyOptions}"
+                                    SelectedItem="{Binding SelectedSystem.ReviewFrequencyMonths}" />
+
+                            <Label Text="Last Backup Verification Date" FontAttributes="Bold" TextColor="#334155"/>
+                            <DatePicker Date="{Binding SelectedSystem.LastBackupDate}" />
+
+                            <Label Text="Backup Verification Frequency (months)" FontAttributes="Bold" TextColor="#334155"/>
+                            <Picker Title="Select frequency"
+                                    ItemsSource="{Binding FrequencyOptions}"
+                                    SelectedItem="{Binding SelectedSystem.BackupFrequencyMonths}" />
+
+                            <Label Text="Last Audit Trail Review Date" FontAttributes="Bold" TextColor="#334155"/>
+                            <DatePicker Date="{Binding SelectedSystem.LastAuditTrailReviewDate}" />
+
+                            <Label Text="Audit Trail Review Frequency (months)" FontAttributes="Bold" TextColor="#334155"/>
+                            <Picker Title="Select frequency"
+                                    ItemsSource="{Binding FrequencyOptions}"
+                                    SelectedItem="{Binding SelectedSystem.AuditTrailFrequencyMonths}" />
+
+                        </VerticalStackLayout>
+                    </Border>
 
                     <Button Text="Save Changes"
+                            FontAttributes="Bold"
+                            HeightRequest="48"
                             BackgroundColor="#A78BFA"
                             TextColor="White"
-                            CornerRadius="12"
+                            CornerRadius="14"
                             Clicked="OnSaveClicked"/>
 
                 </VerticalStackLayout>

--- a/Views/MainPage.xaml
+++ b/Views/MainPage.xaml
@@ -26,115 +26,95 @@
                    Margin="0,10,0,0" />
 
             <Grid ColumnDefinitions="*,*"
-                  RowDefinitions="Auto,Auto,Auto"
+                  RowDefinitions="Auto,Auto,Auto,Auto"
                   ColumnSpacing="12"
                   RowSpacing="12">
 
-                <Border Grid.Row="0"
-                        Grid.Column="0"
+                <Border Grid.Row="0" Grid.Column="0"
                         StrokeThickness="0"
                         BackgroundColor="#DBEAFE"
                         Padding="16"
                         StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="Total Systems"
-                               FontSize="14"
-                               FontAttributes="Bold"
-                               TextColor="#1E3A8A" />
-                        <Label Text="{Binding TotalSystems}"
-                               FontSize="30"
-                               FontAttributes="Bold"
-                               TextColor="#1E3A8A" />
+                        <Label Text="Total Systems" FontSize="14" FontAttributes="Bold" TextColor="#1E3A8A" />
+                        <Label Text="{Binding TotalSystems}" FontSize="30" FontAttributes="Bold" TextColor="#1E3A8A" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="0"
-                        Grid.Column="1"
+                <Border Grid.Row="0" Grid.Column="1"
                         StrokeThickness="0"
                         BackgroundColor="#D1FAE5"
                         Padding="16"
                         StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="GxP Relevant"
-                               FontSize="14"
-                               FontAttributes="Bold"
-                               TextColor="#065F46" />
-                        <Label Text="{Binding GxpRelevantSystems}"
-                               FontSize="30"
-                               FontAttributes="Bold"
-                               TextColor="#065F46" />
+                        <Label Text="GxP Relevant" FontSize="14" FontAttributes="Bold" TextColor="#065F46" />
+                        <Label Text="{Binding GxpRelevantSystems}" FontSize="30" FontAttributes="Bold" TextColor="#065F46" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="1"
-                        Grid.Column="0"
+                <Border Grid.Row="1" Grid.Column="0"
                         StrokeThickness="0"
                         BackgroundColor="#EDE9FE"
                         Padding="16"
                         StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="Validated"
-                               FontSize="14"
-                               FontAttributes="Bold"
-                               TextColor="#5B21B6" />
-                        <Label Text="{Binding ValidatedSystems}"
-                               FontSize="30"
-                               FontAttributes="Bold"
-                               TextColor="#5B21B6" />
+                        <Label Text="Validated" FontSize="14" FontAttributes="Bold" TextColor="#5B21B6" />
+                        <Label Text="{Binding ValidatedSystems}" FontSize="30" FontAttributes="Bold" TextColor="#5B21B6" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="1"
-                        Grid.Column="1"
+                <Border Grid.Row="1" Grid.Column="1"
                         StrokeThickness="0"
                         BackgroundColor="#FEF3C7"
                         Padding="16"
                         StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="In Progress"
-                               FontSize="14"
-                               FontAttributes="Bold"
-                               TextColor="#92400E" />
-                        <Label Text="{Binding InProgressSystems}"
-                               FontSize="30"
-                               FontAttributes="Bold"
-                               TextColor="#92400E" />
+                        <Label Text="In Progress" FontSize="14" FontAttributes="Bold" TextColor="#92400E" />
+                        <Label Text="{Binding InProgressSystems}" FontSize="30" FontAttributes="Bold" TextColor="#92400E" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="2"
-                        Grid.Column="0"
+                <Border Grid.Row="2" Grid.Column="0"
                         StrokeThickness="0"
                         BackgroundColor="#FCE7F3"
                         Padding="16"
                         StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="Not Validated"
-                               FontSize="14"
-                               FontAttributes="Bold"
-                               TextColor="#9D174D" />
-                        <Label Text="{Binding NotValidatedSystems}"
-                               FontSize="30"
-                               FontAttributes="Bold"
-                               TextColor="#9D174D" />
+                        <Label Text="Not Validated" FontSize="14" FontAttributes="Bold" TextColor="#9D174D" />
+                        <Label Text="{Binding NotValidatedSystems}" FontSize="30" FontAttributes="Bold" TextColor="#9D174D" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="2"
-                        Grid.Column="1"
+                <Border Grid.Row="2" Grid.Column="1"
                         StrokeThickness="0"
                         BackgroundColor="#E5E7EB"
                         Padding="16"
                         StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
-                        <Label Text="Obsolete"
-                               FontSize="14"
-                               FontAttributes="Bold"
-                               TextColor="#374151" />
-                        <Label Text="{Binding ObsoleteSystemsCount}"
-                               FontSize="30"
-                               FontAttributes="Bold"
-                               TextColor="#374151" />
+                        <Label Text="Obsolete" FontSize="14" FontAttributes="Bold" TextColor="#374151" />
+                        <Label Text="{Binding ObsoleteSystemsCount}" FontSize="30" FontAttributes="Bold" TextColor="#374151" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border Grid.Row="3" Grid.Column="0"
+                        StrokeThickness="0"
+                        BackgroundColor="#FFEDD5"
+                        Padding="16"
+                        StrokeShape="RoundRectangle 18">
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Upcoming Tasks" FontSize="14" FontAttributes="Bold" TextColor="#9A3412" />
+                        <Label Text="{Binding UpcomingComplianceTasks}" FontSize="30" FontAttributes="Bold" TextColor="#9A3412" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border Grid.Row="3" Grid.Column="1"
+                        StrokeThickness="0"
+                        BackgroundColor="#FEE2E2"
+                        Padding="16"
+                        StrokeShape="RoundRectangle 18">
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Overdue Tasks" FontSize="14" FontAttributes="Bold" TextColor="#991B1B" />
+                        <Label Text="{Binding OverdueComplianceTasks}" FontSize="30" FontAttributes="Bold" TextColor="#991B1B" />
                     </VerticalStackLayout>
                 </Border>
 
@@ -163,14 +143,14 @@
                                 Padding="18"
                                 Margin="0,8"
                                 BackgroundColor="#FFFFFF"
-                                StrokeShape="RoundRectangle 16">
+                                StrokeShape="RoundRectangle 18">
 
-                            <VerticalStackLayout Spacing="10"
-                                                 BackgroundColor="#F1F5F9"
-                                                 Padding="14">
+                            <VerticalStackLayout Spacing="14"
+                                                 BackgroundColor="#F8FAFC"
+                                                 Padding="16">
 
                                 <Label Text="{Binding SystemName}"
-                                       FontSize="20"
+                                       FontSize="21"
                                        FontAttributes="Bold"
                                        TextColor="#111827" />
 
@@ -179,66 +159,118 @@
                                       RowSpacing="8"
                                       ColumnSpacing="10">
 
-                                    <Label Grid.Row="0" Grid.Column="0"
-                                           Text="System ID:"
-                                           FontAttributes="Bold"
-                                           TextColor="#475569" />
-                                    <Label Grid.Row="0" Grid.Column="1"
-                                           Text="{Binding SystemCode}"
-                                           TextColor="#334155" />
+                                    <Label Grid.Row="0" Grid.Column="0" Text="System ID:" FontAttributes="Bold" TextColor="#475569" />
+                                    <Label Grid.Row="0" Grid.Column="1" Text="{Binding SystemCode}" TextColor="#334155" />
 
-                                    <Label Grid.Row="1" Grid.Column="0"
-                                           Text="System Owner:"
-                                           FontAttributes="Bold"
-                                           TextColor="#475569" />
-                                    <Label Grid.Row="1" Grid.Column="1"
-                                           Text="{Binding Owner}"
-                                           TextColor="#334155" />
+                                    <Label Grid.Row="1" Grid.Column="0" Text="System Owner:" FontAttributes="Bold" TextColor="#475569" />
+                                    <Label Grid.Row="1" Grid.Column="1" Text="{Binding Owner}" TextColor="#334155" />
 
-                                    <Label Grid.Row="2" Grid.Column="0"
-                                           Text="Vendor:"
-                                           FontAttributes="Bold"
-                                           TextColor="#475569" />
-                                    <Label Grid.Row="2" Grid.Column="1"
-                                           Text="{Binding Vendor}"
-                                           TextColor="#334155" />
+                                    <Label Grid.Row="2" Grid.Column="0" Text="Vendor:" FontAttributes="Bold" TextColor="#475569" />
+                                    <Label Grid.Row="2" Grid.Column="1" Text="{Binding Vendor}" TextColor="#334155" />
 
-                                    <Label Grid.Row="3" Grid.Column="0"
-                                           Text="Software Version:"
-                                           FontAttributes="Bold"
-                                           TextColor="#475569" />
-                                    <Label Grid.Row="3" Grid.Column="1"
-                                           Text="{Binding SoftwareVersion}"
-                                           TextColor="#334155" />
+                                    <Label Grid.Row="3" Grid.Column="0" Text="Software Version:" FontAttributes="Bold" TextColor="#475569" />
+                                    <Label Grid.Row="3" Grid.Column="1" Text="{Binding SoftwareVersion}" TextColor="#334155" />
 
-                                    <Label Grid.Row="4" Grid.Column="0"
-                                           Text="GAMP 5 Category:"
-                                           FontAttributes="Bold"
-                                           TextColor="#475569" />
-                                    <Label Grid.Row="4" Grid.Column="1"
-                                           Text="{Binding GampCategory}"
-                                           TextColor="#6D28D9"
-                                           FontAttributes="Bold" />
+                                    <Label Grid.Row="4" Grid.Column="0" Text="GAMP 5 Category:" FontAttributes="Bold" TextColor="#475569" />
+                                    <Label Grid.Row="4" Grid.Column="1" Text="{Binding GampCategory}" TextColor="#6D28D9" FontAttributes="Bold" />
 
-                                    <Label Grid.Row="5" Grid.Column="0"
-                                           Text="GxP Relevant:"
-                                           FontAttributes="Bold"
-                                           TextColor="#475569" />
-                                    <Label Grid.Row="5" Grid.Column="1"
-                                           Text="{Binding IsGxpRelevant}"
-                                           TextColor="#047857"
-                                           FontAttributes="Bold" />
+                                    <Label Grid.Row="5" Grid.Column="0" Text="GxP Relevant:" FontAttributes="Bold" TextColor="#475569" />
+                                    <Label Grid.Row="5" Grid.Column="1" Text="{Binding IsGxpRelevant}" TextColor="#047857" FontAttributes="Bold" />
 
-                                    <Label Grid.Row="6" Grid.Column="0"
-                                           Text="Validation Status:"
-                                           FontAttributes="Bold"
-                                           TextColor="#475569" />
-                                    <Label Grid.Row="6" Grid.Column="1"
-                                           Text="{Binding ValidationStatus}"
-                                           TextColor="#2563EB"
-                                           FontAttributes="Bold" />
+                                    <Label Grid.Row="6" Grid.Column="0" Text="Validation Status:" FontAttributes="Bold" TextColor="#475569" />
+                                    <Label Grid.Row="6" Grid.Column="1" Text="{Binding ValidationStatus}" TextColor="#2563EB" FontAttributes="Bold" />
 
                                 </Grid>
+
+                                <Border StrokeThickness="0"
+                                        BackgroundColor="#EEF2FF"
+                                        Padding="14"
+                                        StrokeShape="RoundRectangle 14">
+
+                                    <VerticalStackLayout Spacing="12">
+
+                                        <Label Text="Compliance Schedule"
+                                               FontSize="16"
+                                               FontAttributes="Bold"
+                                               TextColor="#3730A3" />
+
+                                        <Border StrokeThickness="0"
+                                                BackgroundColor="#FFFFFF"
+                                                Padding="12"
+                                                StrokeShape="RoundRectangle 12">
+                                            <VerticalStackLayout Spacing="6">
+                                                <Label Text="Periodic Review"
+                                                       FontAttributes="Bold"
+                                                       TextColor="#1E293B" />
+
+                                                <Label Text="{Binding LastReviewDate, StringFormat='Last completed: {0:dd MMM yyyy}'}"
+                                                       TextColor="#475569" />
+
+                                                <Label Text="{Binding ReviewFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}"
+                                                       TextColor="#475569" />
+
+                                                <Label Text="{Binding NextReviewDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}"
+                                                       TextColor="#334155"
+                                                       FontAttributes="Bold" />
+
+                                                <Label Text="{Binding ReviewStatusMessage}"
+                                                       TextColor="#9A3412"
+                                                       FontAttributes="Bold" />
+                                            </VerticalStackLayout>
+                                        </Border>
+
+                                        <Border StrokeThickness="0"
+                                                BackgroundColor="#FFFFFF"
+                                                Padding="12"
+                                                StrokeShape="RoundRectangle 12">
+                                            <VerticalStackLayout Spacing="6">
+                                                <Label Text="Backup Verification"
+                                                       FontAttributes="Bold"
+                                                       TextColor="#1E293B" />
+
+                                                <Label Text="{Binding LastBackupDate, StringFormat='Last completed: {0:dd MMM yyyy}'}"
+                                                       TextColor="#475569" />
+
+                                                <Label Text="{Binding BackupFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}"
+                                                       TextColor="#475569" />
+
+                                                <Label Text="{Binding NextBackupDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}"
+                                                       TextColor="#334155"
+                                                       FontAttributes="Bold" />
+
+                                                <Label Text="{Binding BackupStatusMessage}"
+                                                       TextColor="#9A3412"
+                                                       FontAttributes="Bold" />
+                                            </VerticalStackLayout>
+                                        </Border>
+
+                                        <Border StrokeThickness="0"
+                                                BackgroundColor="#FFFFFF"
+                                                Padding="12"
+                                                StrokeShape="RoundRectangle 12">
+                                            <VerticalStackLayout Spacing="6">
+                                                <Label Text="Audit Trail Review"
+                                                       FontAttributes="Bold"
+                                                       TextColor="#1E293B" />
+
+                                                <Label Text="{Binding LastAuditTrailReviewDate, StringFormat='Last completed: {0:dd MMM yyyy}'}"
+                                                       TextColor="#475569" />
+
+                                                <Label Text="{Binding AuditTrailFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}"
+                                                       TextColor="#475569" />
+
+                                                <Label Text="{Binding NextAuditTrailDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}"
+                                                       TextColor="#334155"
+                                                       FontAttributes="Bold" />
+
+                                                <Label Text="{Binding AuditTrailStatusMessage}"
+                                                       TextColor="#9A3412"
+                                                       FontAttributes="Bold" />
+                                            </VerticalStackLayout>
+                                        </Border>
+
+                                    </VerticalStackLayout>
+                                </Border>
 
                                 <Button Text="Mark as Obsolete"
                                         BackgroundColor="#FCA5A5"


### PR DESCRIPTION
This pull request implements the compliance reminder functionality for the GxP System Inventory and Compliance Reminder App.

Changes include:
- Added fields for Periodic Review, Backup Verification, and Audit Trail Review dates and frequencies.
- Added automatic next due date calculation based on last completed date plus frequency in months.
- Added reminder status messages showing due today, due in X days, or overdue by X days.
- Updated dashboard logic to count upcoming and overdue compliance tasks.
- Updated inventory cards to display last completed date, frequency, next due date, and reminder status.
- Updated SQLite database version/name to create a clean local database for the new fields.

This supports the compliance reminder module defined in the project design and improves visibility of upcoming and overdue compliance activities.