### PR TITLE
Add reporting page for system inventory summary

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -10,6 +10,7 @@ namespace CSVGxpInventoryApp
 
             Routing.RegisterRoute(nameof(AddSystemPage), typeof(AddSystemPage));
             Routing.RegisterRoute(nameof(EditSystemPage), typeof(EditSystemPage));
+            Routing.RegisterRoute(nameof(ReportPage), typeof(ReportPage));
         }
     }
 }

--- a/CSVGxpInventoryApp.csproj
+++ b/CSVGxpInventoryApp.csproj
@@ -83,6 +83,9 @@
 	  <MauiXaml Update="Views\EditSystemPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\ReportPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	</ItemGroup>
 
 </Project>

--- a/Views/MainPage.xaml
+++ b/Views/MainPage.xaml
@@ -30,88 +30,56 @@
                   ColumnSpacing="12"
                   RowSpacing="12">
 
-                <Border Grid.Row="0" Grid.Column="0"
-                        StrokeThickness="0"
-                        BackgroundColor="#DBEAFE"
-                        Padding="16"
-                        StrokeShape="RoundRectangle 18">
+                <Border Grid.Row="0" Grid.Column="0" StrokeThickness="0" BackgroundColor="#DBEAFE" Padding="16" StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Total Systems" FontSize="14" FontAttributes="Bold" TextColor="#1E3A8A" />
                         <Label Text="{Binding TotalSystems}" FontSize="30" FontAttributes="Bold" TextColor="#1E3A8A" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="0" Grid.Column="1"
-                        StrokeThickness="0"
-                        BackgroundColor="#D1FAE5"
-                        Padding="16"
-                        StrokeShape="RoundRectangle 18">
+                <Border Grid.Row="0" Grid.Column="1" StrokeThickness="0" BackgroundColor="#D1FAE5" Padding="16" StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="GxP Relevant" FontSize="14" FontAttributes="Bold" TextColor="#065F46" />
                         <Label Text="{Binding GxpRelevantSystems}" FontSize="30" FontAttributes="Bold" TextColor="#065F46" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="1" Grid.Column="0"
-                        StrokeThickness="0"
-                        BackgroundColor="#EDE9FE"
-                        Padding="16"
-                        StrokeShape="RoundRectangle 18">
+                <Border Grid.Row="1" Grid.Column="0" StrokeThickness="0" BackgroundColor="#EDE9FE" Padding="16" StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Validated" FontSize="14" FontAttributes="Bold" TextColor="#5B21B6" />
                         <Label Text="{Binding ValidatedSystems}" FontSize="30" FontAttributes="Bold" TextColor="#5B21B6" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="1" Grid.Column="1"
-                        StrokeThickness="0"
-                        BackgroundColor="#FEF3C7"
-                        Padding="16"
-                        StrokeShape="RoundRectangle 18">
+                <Border Grid.Row="1" Grid.Column="1" StrokeThickness="0" BackgroundColor="#FEF3C7" Padding="16" StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="In Progress" FontSize="14" FontAttributes="Bold" TextColor="#92400E" />
                         <Label Text="{Binding InProgressSystems}" FontSize="30" FontAttributes="Bold" TextColor="#92400E" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="2" Grid.Column="0"
-                        StrokeThickness="0"
-                        BackgroundColor="#FCE7F3"
-                        Padding="16"
-                        StrokeShape="RoundRectangle 18">
+                <Border Grid.Row="2" Grid.Column="0" StrokeThickness="0" BackgroundColor="#FCE7F3" Padding="16" StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Not Validated" FontSize="14" FontAttributes="Bold" TextColor="#9D174D" />
                         <Label Text="{Binding NotValidatedSystems}" FontSize="30" FontAttributes="Bold" TextColor="#9D174D" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="2" Grid.Column="1"
-                        StrokeThickness="0"
-                        BackgroundColor="#E5E7EB"
-                        Padding="16"
-                        StrokeShape="RoundRectangle 18">
+                <Border Grid.Row="2" Grid.Column="1" StrokeThickness="0" BackgroundColor="#E5E7EB" Padding="16" StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Obsolete" FontSize="14" FontAttributes="Bold" TextColor="#374151" />
                         <Label Text="{Binding ObsoleteSystemsCount}" FontSize="30" FontAttributes="Bold" TextColor="#374151" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="3" Grid.Column="0"
-                        StrokeThickness="0"
-                        BackgroundColor="#FFEDD5"
-                        Padding="16"
-                        StrokeShape="RoundRectangle 18">
+                <Border Grid.Row="3" Grid.Column="0" StrokeThickness="0" BackgroundColor="#FFEDD5" Padding="16" StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Upcoming Tasks" FontSize="14" FontAttributes="Bold" TextColor="#9A3412" />
                         <Label Text="{Binding UpcomingComplianceTasks}" FontSize="30" FontAttributes="Bold" TextColor="#9A3412" />
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Grid.Row="3" Grid.Column="1"
-                        StrokeThickness="0"
-                        BackgroundColor="#FEE2E2"
-                        Padding="16"
-                        StrokeShape="RoundRectangle 18">
+                <Border Grid.Row="3" Grid.Column="1" StrokeThickness="0" BackgroundColor="#FEE2E2" Padding="16" StrokeShape="RoundRectangle 18">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Overdue Tasks" FontSize="14" FontAttributes="Bold" TextColor="#991B1B" />
                         <Label Text="{Binding OverdueComplianceTasks}" FontSize="30" FontAttributes="Bold" TextColor="#991B1B" />
@@ -128,11 +96,13 @@
                     CornerRadius="14"
                     Clicked="OnAddSystemClicked" />
 
-            <Label Text="System Inventory List"
-                   FontSize="20"
-                   FontAttributes="Bold"
-                   TextColor="#1E293B"
-                   Margin="0,8,0,0" />
+            <Button Text="View Report"
+                    FontAttributes="Bold"
+                    HeightRequest="50"
+                    BackgroundColor="#34D399"
+                    TextColor="White"
+                    CornerRadius="14"
+                    Clicked="OnViewReportClicked" />
 
             <Border StrokeThickness="0"
                     BackgroundColor="#FFFFFF"
@@ -184,6 +154,12 @@
 
                 </VerticalStackLayout>
             </Border>
+
+            <Label Text="System Inventory List"
+                   FontSize="20"
+                   FontAttributes="Bold"
+                   TextColor="#1E293B"
+                   Margin="0,8,0,0" />
 
             <CollectionView ItemsSource="{Binding Systems}">
                 <CollectionView.ItemTemplate>
@@ -245,78 +221,33 @@
                                                FontAttributes="Bold"
                                                TextColor="#3730A3" />
 
-                                        <Border StrokeThickness="0"
-                                                BackgroundColor="#FFFFFF"
-                                                Padding="12"
-                                                StrokeShape="RoundRectangle 12">
+                                        <Border StrokeThickness="0" BackgroundColor="#FFFFFF" Padding="12" StrokeShape="RoundRectangle 12">
                                             <VerticalStackLayout Spacing="6">
-                                                <Label Text="Periodic Review"
-                                                       FontAttributes="Bold"
-                                                       TextColor="#1E293B" />
-
-                                                <Label Text="{Binding LastReviewDate, StringFormat='Last completed: {0:dd MMM yyyy}'}"
-                                                       TextColor="#475569" />
-
-                                                <Label Text="{Binding ReviewFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}"
-                                                       TextColor="#475569" />
-
-                                                <Label Text="{Binding NextReviewDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}"
-                                                       TextColor="#334155"
-                                                       FontAttributes="Bold" />
-
-                                                <Label Text="{Binding ReviewStatusMessage}"
-                                                       TextColor="#9A3412"
-                                                       FontAttributes="Bold" />
+                                                <Label Text="Periodic Review" FontAttributes="Bold" TextColor="#1E293B" />
+                                                <Label Text="{Binding LastReviewDate, StringFormat='Last completed: {0:dd MMM yyyy}'}" TextColor="#475569" />
+                                                <Label Text="{Binding ReviewFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}" TextColor="#475569" />
+                                                <Label Text="{Binding NextReviewDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}" TextColor="#334155" FontAttributes="Bold" />
+                                                <Label Text="{Binding ReviewStatusMessage}" TextColor="#9A3412" FontAttributes="Bold" />
                                             </VerticalStackLayout>
                                         </Border>
 
-                                        <Border StrokeThickness="0"
-                                                BackgroundColor="#FFFFFF"
-                                                Padding="12"
-                                                StrokeShape="RoundRectangle 12">
+                                        <Border StrokeThickness="0" BackgroundColor="#FFFFFF" Padding="12" StrokeShape="RoundRectangle 12">
                                             <VerticalStackLayout Spacing="6">
-                                                <Label Text="Backup Verification"
-                                                       FontAttributes="Bold"
-                                                       TextColor="#1E293B" />
-
-                                                <Label Text="{Binding LastBackupDate, StringFormat='Last completed: {0:dd MMM yyyy}'}"
-                                                       TextColor="#475569" />
-
-                                                <Label Text="{Binding BackupFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}"
-                                                       TextColor="#475569" />
-
-                                                <Label Text="{Binding NextBackupDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}"
-                                                       TextColor="#334155"
-                                                       FontAttributes="Bold" />
-
-                                                <Label Text="{Binding BackupStatusMessage}"
-                                                       TextColor="#9A3412"
-                                                       FontAttributes="Bold" />
+                                                <Label Text="Backup Verification" FontAttributes="Bold" TextColor="#1E293B" />
+                                                <Label Text="{Binding LastBackupDate, StringFormat='Last completed: {0:dd MMM yyyy}'}" TextColor="#475569" />
+                                                <Label Text="{Binding BackupFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}" TextColor="#475569" />
+                                                <Label Text="{Binding NextBackupDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}" TextColor="#334155" FontAttributes="Bold" />
+                                                <Label Text="{Binding BackupStatusMessage}" TextColor="#9A3412" FontAttributes="Bold" />
                                             </VerticalStackLayout>
                                         </Border>
 
-                                        <Border StrokeThickness="0"
-                                                BackgroundColor="#FFFFFF"
-                                                Padding="12"
-                                                StrokeShape="RoundRectangle 12">
+                                        <Border StrokeThickness="0" BackgroundColor="#FFFFFF" Padding="12" StrokeShape="RoundRectangle 12">
                                             <VerticalStackLayout Spacing="6">
-                                                <Label Text="Audit Trail Review"
-                                                       FontAttributes="Bold"
-                                                       TextColor="#1E293B" />
-
-                                                <Label Text="{Binding LastAuditTrailReviewDate, StringFormat='Last completed: {0:dd MMM yyyy}'}"
-                                                       TextColor="#475569" />
-
-                                                <Label Text="{Binding AuditTrailFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}"
-                                                       TextColor="#475569" />
-
-                                                <Label Text="{Binding NextAuditTrailDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}"
-                                                       TextColor="#334155"
-                                                       FontAttributes="Bold" />
-
-                                                <Label Text="{Binding AuditTrailStatusMessage}"
-                                                       TextColor="#9A3412"
-                                                       FontAttributes="Bold" />
+                                                <Label Text="Audit Trail Review" FontAttributes="Bold" TextColor="#1E293B" />
+                                                <Label Text="{Binding LastAuditTrailReviewDate, StringFormat='Last completed: {0:dd MMM yyyy}'}" TextColor="#475569" />
+                                                <Label Text="{Binding AuditTrailFrequencyMonths, StringFormat='Frequency: every {0} month(s)'}" TextColor="#475569" />
+                                                <Label Text="{Binding NextAuditTrailDueDate, StringFormat='Next due: {0:dd MMM yyyy}'}" TextColor="#334155" FontAttributes="Bold" />
+                                                <Label Text="{Binding AuditTrailStatusMessage}" TextColor="#9A3412" FontAttributes="Bold" />
                                             </VerticalStackLayout>
                                         </Border>
 

--- a/Views/MainPage.xaml.cs
+++ b/Views/MainPage.xaml.cs
@@ -28,6 +28,11 @@ public partial class MainPage : ContentPage
         await Shell.Current.GoToAsync(nameof(AddSystemPage));
     }
 
+    private async void OnViewReportClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync(nameof(ReportPage));
+    }
+
     private async void OnEditClicked(object sender, EventArgs e)
     {
         if (sender is Button button && button.BindingContext is SystemEntity selectedSystem)

--- a/Views/ReportPage.xaml
+++ b/Views/ReportPage.xaml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="CSVGxpInventoryApp.Views.ReportPage"
+             Title="System Report"
+             BackgroundColor="#EEF2F7">
+
+    <ScrollView>
+        <VerticalStackLayout Padding="22" Spacing="16">
+
+            <Label Text="System Inventory Report"
+                   FontSize="26"
+                   FontAttributes="Bold"
+                   HorizontalOptions="Center"
+                   TextColor="#1E293B"/>
+
+            <!-- Summary -->
+            <Border BackgroundColor="#FFFFFF"
+                    Padding="16"
+                    StrokeShape="RoundRectangle 16">
+
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Summary"
+                           FontSize="18"
+                           FontAttributes="Bold"/>
+
+                    <Label Text="{Binding TotalSystems, StringFormat='Total Active Systems: {0}'}"/>
+                    <Label Text="{Binding ObsoleteSystemsCount, StringFormat='Obsolete Systems: {0}'}"/>
+                    <Label Text="{Binding GxpRelevantSystems, StringFormat='GxP Relevant Systems: {0}'}"/>
+                </VerticalStackLayout>
+
+            </Border>
+
+            <!-- Validation Status -->
+            <Border BackgroundColor="#FFFFFF"
+                    Padding="16"
+                    StrokeShape="RoundRectangle 16">
+
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Validation Status Breakdown"
+                           FontSize="18"
+                           FontAttributes="Bold"/>
+
+                    <Label Text="{Binding ValidatedSystems, StringFormat='Validated: {0}'}"/>
+                    <Label Text="{Binding InProgressSystems, StringFormat='In Progress: {0}'}"/>
+                    <Label Text="{Binding NotValidatedSystems, StringFormat='Not Validated: {0}'}"/>
+                </VerticalStackLayout>
+
+            </Border>
+
+            <!-- Compliance -->
+            <Border BackgroundColor="#FFFFFF"
+                    Padding="16"
+                    StrokeShape="RoundRectangle 16">
+
+                <VerticalStackLayout Spacing="10">
+                    <Label Text="Compliance Overview"
+                           FontSize="18"
+                           FontAttributes="Bold"/>
+
+                    <Label Text="{Binding UpcomingComplianceTasks, StringFormat='Upcoming Tasks: {0}'}"/>
+                    <Label Text="{Binding OverdueComplianceTasks, StringFormat='Overdue Tasks: {0}'}"/>
+                </VerticalStackLayout>
+
+            </Border>
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/Views/ReportPage.xaml.cs
+++ b/Views/ReportPage.xaml.cs
@@ -1,0 +1,20 @@
+using CSVGxpInventoryApp.ViewModels;
+
+namespace CSVGxpInventoryApp.Views;
+
+public partial class ReportPage : ContentPage
+{
+    private readonly SystemViewModel _viewModel;
+
+    public ReportPage(SystemViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = _viewModel = viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _viewModel.LoadSystemsAsync();
+    }
+}


### PR DESCRIPTION
This pull request introduces a reporting page to the GxP System Inventory and Compliance Reminder App.

Changes include:
- Created a new ReportPage to display system inventory summary information
- Added summary metrics including total active systems, obsolete systems, and GxP relevant systems
- Added validation status breakdown (Validated, In Progress, Not Validated)
- Added compliance overview showing upcoming and overdue tasks
- Implemented navigation from the main page to the reporting page
- Registered the ReportPage route in AppShell

The reporting page reuses existing ViewModel data and does not require additional database changes.

This feature satisfies the functional requirement for system inventory and compliance reporting and improves visibility of key system metrics.